### PR TITLE
add vue-template-compiler as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "prettier": "^1.11.1",
     "source-map": "^0.5.6",
     "vue-template-es2015-compiler": "^1.6.0"
+  },
+  "peerDependencies": {
+    "vue-template-compiler": "^2.5.16"
   }
 }


### PR DESCRIPTION
If `vue-template-compiler` is not included but you try to parse anything it throws an error saying it can't be found.
Adding it as a peer dependency would prevent this.
as discussed in https://github.com/parcel-bundler/parcel/pull/1052