### PR TITLE
fix: default parser was removed from prettier

### DIFF
--- a/lib/compileTemplate.ts
+++ b/lib/compileTemplate.ts
@@ -158,7 +158,7 @@ function actuallyCompile (
       // mark with stripped (this enables Vue to use correct runtime proxy
       // detection)
       code += `render._withStripped = true`
-      code = prettier.format(code, { semi: false })
+      code = prettier.format(code, { semi: false, parser: 'babylon' })
     }
 
     return {


### PR DESCRIPTION
see https://github.com/prettier/prettier/issues/4567