### PR TITLE
 feat: Support uri fragment in transformed require

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Lower level utilities for compiling Vue single file components
 
-This package contains lower level utilities that you can use if you are writing a plugin / transform for a bundler or module system that compiles Vue single file components into JavaScript. It is used in [vue-loader](https://github.com/vuejs/vue-loader) version 15 and above.
+This package contains lower level utilities that you can use if you are writing a plugin / transform for a bundler or module system that compiles Vue single file components into JavaScript. It is used in [vue-loader](https://github.com/vuejs/vue-loader) version 15 and above or [vue-template-loader](https://github.com/ktsn/vue-template-loader) version 1.0.0 and above.
 
 The API surface is intentionally minimal - the goal is to reuse as much as possible while being as flexible as possible.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Lower level utilities for compiling Vue single file components
 
-This package contains lower level utilities that you can use if you are writing a plugin / transform for a bundler or module system that compiles Vue single file components into JavaScript. It is used in [vue-loader](https://github.com/vuejs/vue-loader) version 15 and above or [vue-template-loader](https://github.com/ktsn/vue-template-loader) version 1.0.0 and above.
+This package contains lower level utilities that you can use if you are writing a plugin / transform for a bundler or module system that compiles Vue single file components into JavaScript. It is used in [vue-loader](https://github.com/vuejs/vue-loader) version 15 and above.
 
 The API surface is intentionally minimal - the goal is to reuse as much as possible while being as flexible as possible.
 
@@ -18,7 +18,7 @@ Not listing it as a peer depedency also allows tooling authors to use a non-defa
 
 Parse raw single file component source into a descriptor with source maps. The actual compiler (`vue-template-compiler`) must be passed in via the `compiler` option so that the specific version used can be determined by the end user.
 
-``` ts
+```ts
 interface ParseOptions {
   source: string
   filename?: string
@@ -60,7 +60,7 @@ Takes raw template source and compile it into JavaScript code. The actual compil
 
 It can also optionally perform pre-processing for any templating engine supported by [consolidate](https://github.com/tj/consolidate.js/).
 
-``` ts
+```ts
 interface TemplateCompileOptions {
   source: string
   filename: string
@@ -108,9 +108,18 @@ interface AssetURLOptions {
 
 The resulting JavaScript code will look like this:
 
-``` js
-var render = function (h) { /* ... */}
-var staticRenderFns = [function (h) { /* ... */}, function (h) { /* ... */}]
+```js
+var render = function(h) {
+  /* ... */
+}
+var staticRenderFns = [
+  function(h) {
+    /* ... */
+  },
+  function(h) {
+    /* ... */
+  }
+]
 ```
 
 It **does NOT** assume any module system. It is your responsibility to handle the exports, if needed.
@@ -119,7 +128,7 @@ It **does NOT** assume any module system. It is your responsibility to handle th
 
 Take input raw CSS and applies scoped CSS transform. It does NOT handle pre-processors. If the component doesn't use scoped CSS then this step can be skipped.
 
-``` ts
+```ts
 interface StyleCompileOptions {
   source: string
   filename: string

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Not listing it as a peer depedency also allows tooling authors to use a non-defa
 
 Parse raw single file component source into a descriptor with source maps. The actual compiler (`vue-template-compiler`) must be passed in via the `compiler` option so that the specific version used can be determined by the end user.
 
-```ts
+``` ts
 interface ParseOptions {
   source: string
   filename?: string
@@ -60,7 +60,7 @@ Takes raw template source and compile it into JavaScript code. The actual compil
 
 It can also optionally perform pre-processing for any templating engine supported by [consolidate](https://github.com/tj/consolidate.js/).
 
-```ts
+``` ts
 interface TemplateCompileOptions {
   source: string
   filename: string
@@ -108,18 +108,9 @@ interface AssetURLOptions {
 
 The resulting JavaScript code will look like this:
 
-```js
-var render = function(h) {
-  /* ... */
-}
-var staticRenderFns = [
-  function(h) {
-    /* ... */
-  },
-  function(h) {
-    /* ... */
-  }
-]
+``` js
+var render = function (h) { /* ... */}
+var staticRenderFns = [function (h) { /* ... */}, function (h) { /* ... */}]
 ```
 
 It **does NOT** assume any module system. It is your responsibility to handle the exports, if needed.
@@ -128,7 +119,7 @@ It **does NOT** assume any module system. It is your responsibility to handle th
 
 Take input raw CSS and applies scoped CSS transform. It does NOT handle pre-processors. If the component doesn't use scoped CSS then this step can be skipped.
 
-```ts
+``` ts
 interface StyleCompileOptions {
   source: string
   filename: string

--- a/lib/templateCompilerModules/utils.ts
+++ b/lib/templateCompilerModules/utils.ts
@@ -10,8 +10,8 @@ export interface ASTNode {
 
 import { UrlWithStringQuery, parse as uriParse } from 'url'
 
-export function urlToRequire(url: string): string {
-  let returnValue = `"${url}"`
+export function urlToRequire (url: string): string {
+  const returnValue = `"${url}"`
   // same logic as in transform-require.js
   const firstChar = url.charAt(0)
   if (firstChar === '.' || firstChar === '~' || firstChar === '@') {
@@ -22,13 +22,15 @@ export function urlToRequire(url: string): string {
 
     const uriParts = parseUriParts(url)
 
-    !uriParts.hash
-      ? (returnValue = `require("${url}")`)
-      : // support uri fragment case by excluding it from
-        // the require and instead appending it as string;
-        // assuming that the path part is sufficient according to
-        // the above caseing(t.i. no protocol-auth-host parts expected)
-        (returnValue = `require("${uriParts.path}") + "${uriParts.hash}"`)
+    if(!uriParts.hash) {
+      return `require("${url}")`
+    } else{
+      // support uri fragment case by excluding it from
+      // the require and instead appending it as string; 
+      // assuming that the path part is sufficient according to 
+      // the above caseing(t.i. no protocol-auth-host parts expected)
+      return `require("${uriParts.path}") + "${uriParts.hash}"`
+    }
   }
   return returnValue
 }
@@ -37,14 +39,16 @@ export function urlToRequire(url: string): string {
  * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
  * @param urlString an url as a string
  */
-function parseUriParts(urlString: string): UrlWithStringQuery {
-  // initialize return value
-  const returnValue: UrlWithStringQuery = uriParse('')
-  if (urlString) {
-    // A TypeError is thrown if urlString is not a string
-    // @see https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
-    if ('string' === typeof urlString) {
-      // check is an uri
+function parseUriParts(urlString: string): UrlWithStringQuery{
+    // initialize return value
+    const returnValue : UrlWithStringQuery = uriParse('');
+    if(urlString){
+      // A TypeError is thrown if urlString is not a string
+      // @see https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost 
+      if('string' === typeof urlString){
+        // check is an uri
+        // return uriParse(urlString) // take apart the uri
+      }
       return uriParse(urlString) // take apart the uri
     }
   }

--- a/lib/templateCompilerModules/utils.ts
+++ b/lib/templateCompilerModules/utils.ts
@@ -10,7 +10,7 @@ export interface ASTNode {
 
 import { UrlWithStringQuery, parse as uriParse } from 'url'
 
-export function urlToRequire (url: string): string {
+export function urlToRequire(url: string): string {
   const returnValue = `"${url}"`
   // same logic as in transform-require.js
   const firstChar = url.charAt(0)
@@ -22,12 +22,12 @@ export function urlToRequire (url: string): string {
 
     const uriParts = parseUriParts(url)
 
-    if(!uriParts.hash) {
+    if (!uriParts.hash) {
       return `require("${url}")`
-    } else{
+    } else {
       // support uri fragment case by excluding it from
-      // the require and instead appending it as string; 
-      // assuming that the path part is sufficient according to 
+      // the require and instead appending it as string;
+      // assuming that the path part is sufficient according to
       // the above caseing(t.i. no protocol-auth-host parts expected)
       return `require("${uriParts.path}") + "${uriParts.hash}"`
     }
@@ -39,18 +39,17 @@ export function urlToRequire (url: string): string {
  * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
  * @param urlString an url as a string
  */
-function parseUriParts(urlString: string): UrlWithStringQuery{
-    // initialize return value
-    const returnValue : UrlWithStringQuery = uriParse('');
-    if(urlString){
-      // A TypeError is thrown if urlString is not a string
-      // @see https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost 
-      if('string' === typeof urlString){
-        // check is an uri
-        // return uriParse(urlString) // take apart the uri
-      }
-      return uriParse(urlString) // take apart the uri
+function parseUriParts(urlString: string): UrlWithStringQuery {
+  // initialize return value
+  const returnValue: UrlWithStringQuery = uriParse('')
+  if (urlString) {
+    // A TypeError is thrown if urlString is not a string
+    // @see https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
+    if ('string' === typeof urlString) {
+      // check is an uri
+      // return uriParse(urlString) // take apart the uri
     }
+    return uriParse(urlString) // take apart the uri
   }
   return returnValue
 }

--- a/lib/templateCompilerModules/utils.ts
+++ b/lib/templateCompilerModules/utils.ts
@@ -11,7 +11,7 @@ export interface ASTNode {
 import { UrlWithStringQuery, parse as uriParse } from 'url'
 
 export function urlToRequire(url: string): string {
-  const returnValue = `"${url}"`
+  let returnValue = `"${url}"`
   // same logic as in transform-require.js
   const firstChar = url.charAt(0)
   if (firstChar === '.' || firstChar === '~' || firstChar === '@') {
@@ -22,21 +22,19 @@ export function urlToRequire(url: string): string {
 
     const uriParts = parseUriParts(url)
 
-    if (!uriParts.hash) {
-      return `require("${url}")`
-    } else {
-      // support uri fragment case by excluding it from
-      // the require and instead appending it as string;
-      // assuming that the path part is sufficient according to
-      // the above caseing(t.i. no protocol-auth-host parts expected)
-      return `require("${uriParts.path}") + "${uriParts.hash}"`
-    }
+    !uriParts.hash
+      ? (returnValue = `require("${url}")`)
+      : // support uri fragment case by excluding it from
+        // the require and instead appending it as string;
+        // assuming that teh path part is sufficient according to
+        // the above caseing(t.i. no protocol-auth-host parts expected)
+        (returnValue = `require("${uriParts.path}") + "${uriParts.hash}"`)
   }
   return returnValue
 }
 
 /**
- * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
  * @param urlString an url as a string
  */
 function parseUriParts(urlString: string): UrlWithStringQuery {
@@ -47,9 +45,8 @@ function parseUriParts(urlString: string): UrlWithStringQuery {
     // @see https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
     if ('string' === typeof urlString) {
       // check is an uri
-      // return uriParse(urlString) // take apart the uri
+      return uriParse(urlString) // take apart the uri
     }
-    return uriParse(urlString) // take apart the uri
   }
   return returnValue
 }

--- a/lib/templateCompilerModules/utils.ts
+++ b/lib/templateCompilerModules/utils.ts
@@ -47,9 +47,8 @@ function parseUriParts(urlString: string): UrlWithStringQuery {
     // @see https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
     if ('string' === typeof urlString) {
       // check is an uri
-      // return uriParse(urlString) // take apart the uri
+      return uriParse(urlString) // take apart the uri
     }
-    return uriParse(urlString) // take apart the uri
   }
   return returnValue
 }

--- a/lib/templateCompilerModules/utils.ts
+++ b/lib/templateCompilerModules/utils.ts
@@ -10,8 +10,8 @@ export interface ASTNode {
 
 import { UrlWithStringQuery, parse as uriParse } from 'url'
 
-export function urlToRequire (url: string): string {
-  const returnValue = `"${url}"`
+export function urlToRequire(url: string): string {
+  let returnValue = `"${url}"`
   // same logic as in transform-require.js
   const firstChar = url.charAt(0)
   if (firstChar === '.' || firstChar === '~' || firstChar === '@') {
@@ -22,33 +22,29 @@ export function urlToRequire (url: string): string {
 
     const uriParts = parseUriParts(url)
 
-    if(!uriParts.hash) {
-      return `require("${url}")`
-    } else{
-      // support uri fragment case by excluding it from
-      // the require and instead appending it as string; 
-      // assuming that the path part is sufficient according to 
-      // the above caseing(t.i. no protocol-auth-host parts expected)
-      return `require("${uriParts.path}") + "${uriParts.hash}"`
-    }
+    !uriParts.hash
+      ? (returnValue = `require("${url}")`)
+      : // support uri fragment case by excluding it from
+        // the require and instead appending it as string;
+        // assuming that teh path part is sufficient according to
+        // the above caseing(t.i. no protocol-auth-host parts expected)
+        (returnValue = `require("${uriParts.path}") + "${uriParts.hash}"`)
   }
   return returnValue
 }
 
 /**
- * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
  * @param urlString an url as a string
  */
-function parseUriParts(urlString: string): UrlWithStringQuery{
-    // initialize return value
-    const returnValue : UrlWithStringQuery = uriParse('');
-    if(urlString){
-      // A TypeError is thrown if urlString is not a string
-      // @see https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost 
-      if('string' === typeof urlString){
-        // check is an uri
-        // return uriParse(urlString) // take apart the uri
-      }
+function parseUriParts(urlString: string): UrlWithStringQuery {
+  // initialize return value
+  const returnValue: UrlWithStringQuery = uriParse('')
+  if (urlString) {
+    // A TypeError is thrown if urlString is not a string
+    // @see https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
+    if ('string' === typeof urlString) {
+      // check is an uri
       return uriParse(urlString) // take apart the uri
     }
   }

--- a/lib/templateCompilerModules/utils.ts
+++ b/lib/templateCompilerModules/utils.ts
@@ -8,7 +8,10 @@ export interface ASTNode {
   attrs: Attr[]
 }
 
+import { UrlWithStringQuery, parse as uriParse } from 'url'
+
 export function urlToRequire(url: string): string {
+  let returnValue = `"${url}"`
   // same logic as in transform-require.js
   const firstChar = url.charAt(0)
   if (firstChar === '.' || firstChar === '~' || firstChar === '@') {
@@ -16,8 +19,34 @@ export function urlToRequire(url: string): string {
       const secondChar = url.charAt(1)
       url = url.slice(secondChar === '/' ? 2 : 1)
     }
-    return `require("${url}")`
-  } else {
-    return `"${url}"`
+
+    const uriParts = parseUriParts(url)
+
+    !uriParts.hash
+      ? (returnValue = `require("${url}")`)
+      : // support uri fragment case by excluding it from
+        // the require and instead appending it as string;
+        // assuming that teh path part is sufficient according to
+        // the above caseing(t.i. no protocol-auth-host parts expected)
+        (returnValue = `require("${uriParts.path}") + "${uriParts.hash}"`)
   }
+  return returnValue
+}
+
+/**
+ * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
+ * @param urlString an url as a string
+ */
+function parseUriParts(urlString: string): UrlWithStringQuery {
+  // initialize return value
+  const returnValue: UrlWithStringQuery = uriParse('')
+  if (urlString) {
+    // A TypeError is thrown if urlString is not a string
+    // @see https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
+    if ('string' === typeof urlString) {
+      // check is an uri
+      return uriParse(urlString) // take apart the uri
+    }
+  }
+  return returnValue
 }

--- a/lib/templateCompilerModules/utils.ts
+++ b/lib/templateCompilerModules/utils.ts
@@ -26,7 +26,7 @@ export function urlToRequire(url: string): string {
       ? (returnValue = `require("${url}")`)
       : // support uri fragment case by excluding it from
         // the require and instead appending it as string;
-        // assuming that teh path part is sufficient according to
+        // assuming that the path part is sufficient according to
         // the above caseing(t.i. no protocol-auth-host parts expected)
         (returnValue = `require("${uriParts.path}") + "${uriParts.hash}"`)
   }
@@ -34,7 +34,7 @@ export function urlToRequire(url: string): string {
 }
 
 /**
- * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
  * @param urlString an url as a string
  */
 function parseUriParts(urlString: string): UrlWithStringQuery {

--- a/test/compileTemplate.spec.ts
+++ b/test/compileTemplate.spec.ts
@@ -47,7 +47,7 @@ test('preprocess pug', () => {
 })
 
 /**
- * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
  */
 test('supports uri fragment in transformed require', () => {
   const source = //
@@ -69,7 +69,7 @@ test('supports uri fragment in transformed require', () => {
 })
 
 /**
- * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
  */
 test('when too short uri then empty require', () => {
   const source = //

--- a/test/compileTemplate.spec.ts
+++ b/test/compileTemplate.spec.ts
@@ -47,7 +47,7 @@ test('preprocess pug', () => {
 })
 
 /**
- * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
  */
 test('supports uri fragment in transformed require', () => {
   const source = //
@@ -69,7 +69,7 @@ test('supports uri fragment in transformed require', () => {
 })
 
 /**
- * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
  */
 test('when too short uri then empty require', () => {
   const source = //

--- a/test/compileTemplate.spec.ts
+++ b/test/compileTemplate.spec.ts
@@ -47,38 +47,40 @@ test('preprocess pug', () => {
 })
 
 /**
- * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
  */
 test('supports uri fragment in transformed require', () => {
   const source = //
-  '<svg>\
+    '<svg>\
     <use href="~@svg/file.svg#fragment"></use>\
   </svg>'
   const result = compileTemplate({
     filename: 'svgparticle.html',
     source: source,
     transformAssetUrls: {
-      "use": "href"
+      use: 'href'
     },
     compiler: compiler
   })
   expect(result.errors.length).toBe(0)
-  expect(result.code).toMatch(/href: require\("@svg\/file.svg"\) \+ "#fragment"/)
+  expect(result.code).toMatch(
+    /href: require\("@svg\/file.svg"\) \+ "#fragment"/
+  )
 })
 
 /**
- * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
  */
 test('when too short uri then empty require', () => {
   const source = //
-  '<svg>\
+    '<svg>\
     <use href="~"></use>\
   </svg>'
   const result = compileTemplate({
     filename: 'svgparticle.html',
     source: source,
     transformAssetUrls: {
-      "use": "href"
+      use: 'href'
     },
     compiler: compiler
   })

--- a/test/compileTemplate.spec.ts
+++ b/test/compileTemplate.spec.ts
@@ -46,6 +46,46 @@ test('preprocess pug', () => {
   expect(result.errors.length).toBe(0)
 })
 
+/**
+ * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
+ */
+test('supports uri fragment in transformed require', () => {
+  const source = //
+  '<svg>\
+    <use href="~@svg/file.svg#fragment"></use>\
+  </svg>'
+  const result = compileTemplate({
+    filename: 'svgparticle.html',
+    source: source,
+    transformAssetUrls: {
+      "use": "href"
+    },
+    compiler: compiler
+  })
+  expect(result.errors.length).toBe(0)
+  expect(result.code).toMatch(/href: require\("@svg\/file.svg"\) \+ "#fragment"/)
+})
+
+/**
+ * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
+ */
+test('when too short uri then empty require', () => {
+  const source = //
+  '<svg>\
+    <use href="~"></use>\
+  </svg>'
+  const result = compileTemplate({
+    filename: 'svgparticle.html',
+    source: source,
+    transformAssetUrls: {
+      "use": "href"
+    },
+    compiler: compiler
+  })
+  expect(result.errors.length).toBe(0)
+  expect(result.code).toMatch(/href: require\(""\)/)
+})
+
 test('warn missing preprocessor', () => {
   const template = parse({
     source: '<template lang="unknownLang">\n' + '</template>\n',

--- a/test/compileTemplate.spec.ts
+++ b/test/compileTemplate.spec.ts
@@ -47,7 +47,7 @@ test('preprocess pug', () => {
 })
 
 /**
- * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
  */
 test('supports uri fragment in transformed require', () => {
   const source = //
@@ -67,7 +67,7 @@ test('supports uri fragment in transformed require', () => {
 })
 
 /**
- * vuejs/component-compiler-utils#TBD Support uri fragment in transformed require
+ * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
  */
 test('when too short uri then empty require', () => {
   const source = //


### PR DESCRIPTION
My case for this PR is a svg within a html based vue component, where i deployed `vue-template-loader` for this usage. In this html i put a svg element as in
```html
<svg>
    <use href="~@svg/menu.svg#menu"></use>
</svg>
```
Root cause is that the whole href is generated by `component-compiler-utils` and as-is is required by webpack; this must fail because the whole href - including the uri fragment `#menu` - is not part of any mapped physical file location of such an svg.  