### PR TITLE
Fix typings for SFCDescriptor and SFCCustomBlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ interface ParseOptions {
 }
 
 interface SFCDescriptor {
-  template?: SFCBlock
-  script?: SFCBlock
+  template: SFCBlock | null
+  script: SFCBlock | null
   styles: SFCBlock[]
   customBlocks: SFCCustomBlock[]
 }
@@ -40,10 +40,10 @@ interface SFCDescriptor {
 interface SFCCustomBlock {
   type: string
   content: string
-  attrs: { [key: string]: string }
+  attrs: { [key: string]: string | true }
   start: number
   end: number
-  map: RawSourceMap
+  map?: RawSourceMap
 }
 
 interface SFCBlock extends SFCCustomBlock {

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -23,10 +23,10 @@ export interface ParseOptions {
 export interface SFCCustomBlock {
   type: string
   content: string
-  attrs: { [key: string]: string }
+  attrs: { [key: string]: string | true }
   start: number
   end: number
-  map: RawSourceMap
+  map?: RawSourceMap
 }
 
 export interface SFCBlock extends SFCCustomBlock {
@@ -37,8 +37,8 @@ export interface SFCBlock extends SFCCustomBlock {
 }
 
 export interface SFCDescriptor {
-  template?: SFCBlock
-  script?: SFCBlock
+  template: SFCBlock | null
+  script: SFCBlock | null
   styles: SFCBlock[]
   customBlocks: SFCCustomBlock[]
 }


### PR DESCRIPTION
- `sfc.script` and `sfc.template` won't be undefined, see: https://github.com/vuejs/vue/blob/3b43c81216c2e29bd519c447e930d6512b5782e8/src/sfc/parser.js#L24
- sfc.script.map will undefined if `needMap: false` is specified.
- Value of `sfc.script.attrs` can contain `true`, see: https://github.com/vuejs/vue/blob/3b43c81216c2e29bd519c447e930d6512b5782e8/src/sfc/parser.js#L45


(I found this while copying sfc/parser.js of vue into my project, to workaround [this PR](https://github.com/vuejs/vue/pull/8724))