### PR TITLE
Relax Prettier dependency to ^1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "merge-source-map": "^1.1.0",
     "postcss": "^6.0.20",
     "postcss-selector-parser": "^3.1.1",
-    "prettier": "^1.13.7",
+    "prettier": "^1.14.3",
     "source-map": "^0.5.6",
     "vue-template-es2015-compiler": "^1.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "merge-source-map": "^1.1.0",
     "postcss": "^6.0.20",
     "postcss-selector-parser": "^3.1.1",
-    "prettier": "1.13.7",
+    "prettier": "^1.13.7",
     "source-map": "^0.5.6",
     "vue-template-es2015-compiler": "^1.6.0"
   }

--- a/test/compileTemplate.spec.ts
+++ b/test/compileTemplate.spec.ts
@@ -63,10 +63,9 @@ test('preprocess pug', () => {
  * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
  */
 test('supports uri fragment in transformed require', () => {
-  const source = //
-    '<svg>\
+  const source = '<svg>\
     <use href="~@svg/file.svg#fragment"></use>\
-  </svg>'
+  </svg>' //
   const result = compileTemplate({
     filename: 'svgparticle.html',
     source: source,
@@ -85,10 +84,9 @@ test('supports uri fragment in transformed require', () => {
  * vuejs/component-compiler-utils#22 Support uri fragment in transformed require
  */
 test('when too short uri then empty require', () => {
-  const source = //
-    '<svg>\
+  const source = '<svg>\
     <use href="~"></use>\
-  </svg>'
+  </svg>' //
   const result = compileTemplate({
     filename: 'svgparticle.html',
     source: source,


### PR DESCRIPTION
Problem: I have several `prettier`s installed in my new Vue project.

How to reproduce using Vue Cli 3.
* `vue init my-project`
* `npm ls prettier`
```
├─┬ @vue/cli-service@3.0.4
│ └─┬ vue-loader@15.4.2
│   └─┬ @vue/component-compiler-utils@2.2.0
│     └── prettier@1.13.7 
├─┬ @vue/eslint-config-prettier@3.0.4
│ └── prettier@1.14.3  deduped
└── prettier@1.14.3 
```

As you can see the `@vue/component-compiler-utils` dictates the (not latest) prettier version for the entire project.