### PR TITLE
use JSON.stringify in caching parse results

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -53,9 +53,18 @@ export function parse(options: ParseOptions): SFCDescriptor {
     needMap = true
   } = options
   const cacheKey = hash(filename + source)
-  let output: SFCDescriptor = cache.get(cacheKey)
-  if (output) return output
-  output = compiler.parseComponent(source, compilerParseOptions)
+  const cachedOutput: string = cache.get(cacheKey)
+  if (cachedOutput) {
+    try {
+      return JSON.parse(cachedOutput) as SFCDescriptor
+    } catch (_) {
+      // do nothing
+    }
+  }
+  const output: SFCDescriptor = compiler.parseComponent(
+    source,
+    compilerParseOptions
+  )
   if (needMap) {
     if (output.script && !output.script.src) {
       output.script.map = generateSourceMap(
@@ -78,7 +87,7 @@ export function parse(options: ParseOptions): SFCDescriptor {
       })
     }
   }
-  cache.set(cacheKey, output)
+  cache.set(cacheKey, JSON.stringify(output))
   return output
 }
 


### PR DESCRIPTION
In order to fix issue: https://github.com/vuejs/rollup-plugin-vue/issues/239
The reason is that rollup will manipulate the `styles.map.mapping` object, which is in 		https://github.com/rollup/rollup/blob/ea82d134400ecee72e274a02b0e623959e1b36a8/src/utils/transform.ts#L30
```javascript
if (originalSourcemap && typeof originalSourcemap.mappings === 'string')
	originalSourcemap.mappings = decode(originalSourcemap.mappings);
```
So we should return a fresh copy by `JSON.stringify` and `JSON.parse` when the cache is hit.