### PR TITLE
fix(trim): don't insert line break

### DIFF
--- a/lib/stylePlugins/trim.ts
+++ b/lib/stylePlugins/trim.ts
@@ -4,7 +4,7 @@ import * as postcss from 'postcss'
 export default postcss.plugin('trim', () => (css: Root) => {
   css.walk(({ type, raws }) => {
     if (type === 'rule' || type === 'atrule') {
-      raws.before = raws.after = '\n'
+      raws.before = raws.after = ''
     }
   })
 })

--- a/test/compileStyle.spec.ts
+++ b/test/compileStyle.spec.ts
@@ -177,7 +177,7 @@ test('media query', () => {
 
   expect(result.errors).toHaveLength(0)
   expect(result.code).toContain(
-    '@media print {\n.foo[v-scope-xxx] {\n    color: #000;\n}\n}'
+    '@media print {.foo[v-scope-xxx] {\n    color: #000;}}'
   )
 })
 
@@ -196,6 +196,6 @@ test('supports query', () => {
 
   expect(result.errors).toHaveLength(0)
   expect(result.code).toContain(
-    '@supports ( color: #000 ) {\n.foo[v-scope-xxx] {\n    color: #000;\n}\n}'
+    '@supports ( color: #000 ) {.foo[v-scope-xxx] {\n    color: #000;}}'
   )
 })

--- a/test/stylePluginScoped.spec.ts
+++ b/test/stylePluginScoped.spec.ts
@@ -75,9 +75,9 @@ h1 {
 }`
   })
 
-  expect(style).toContain(`.test[v-scope-xxx] {\n  color: yellow;\n}`)
-  expect(style).toContain(`.test[v-scope-xxx]:after {\n  content: \'bye!\';\n}`)
-  expect(style).toContain(`h1[v-scope-xxx] {\n  color: green;\n}`)
+  expect(style).toContain(`.test[v-scope-xxx] {\n  color: yellow;}`)
+  expect(style).toContain(`.test[v-scope-xxx]:after {\n  content: \'bye!\';}`)
+  expect(style).toContain(`h1[v-scope-xxx] {\n  color: green;}`)
   // scoped keyframes
   expect(style).toContain(
     `.anim[v-scope-xxx] {\n  animation: color-v-scope-xxx 5s infinite, other 5s;`
@@ -100,7 +100,7 @@ h1 {
   expect(style).toContain(`@keyframes opacity-v-scope-xxx {`)
   expect(style).toContain(`@-webkit-keyframes opacity-v-scope-xxx {`)
   // >>> combinator
-  expect(style).toContain(`.foo p[v-scope-xxx] .bar {\n  color: red;\n}`)
+  expect(style).toContain(`.foo p[v-scope-xxx] .bar {\n  color: red;}`)
 })
 
 test('pseudo element', () => {


### PR DESCRIPTION
Currently the component CSS is separated by a line break (caused by the `trim` stylePlugin).
Though this can be helpful for debugging, the characters are not necessary at all (at least from what I know).

### Current state

![image](https://user-images.githubusercontent.com/640208/49792868-b2ccfe00-fd2b-11e8-981f-053db2d17a9c.png)


### With fix
![image](https://user-images.githubusercontent.com/640208/49792808-8d3ff480-fd2b-11e8-9208-0c82ab48621c.png)


### Related issues and PRs

https://github.com/vuejs/component-compiler-utils/pull/36
https://github.com/vuejs/vue-loader/issues/1395
https://github.com/cssnano/cssnano/issues/586
https://github.com/nuxt/nuxt.js/issues/4311