### PR TITLE
fix: Generate correct source-map when content is not padded

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,7 +6,7 @@ export interface StartOfSourceMap {
 }
 
 export interface RawSourceMap extends StartOfSourceMap {
-  version: number
+  version: string
   sources: string[]
   names: string[]
   sourcesContent?: string[]

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,7 +6,7 @@ export interface StartOfSourceMap {
 }
 
 export interface RawSourceMap extends StartOfSourceMap {
-  version: string
+  version: number
   sources: string[]
   names: string[]
   sourcesContent?: string[]

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "postcss": "^7.0.7",
     "postcss-selector-parser": "^5.0.0",
     "prettier": "1.13.7",
-    "source-map": "^0.7.3",
+    "source-map": "0.6.1",
     "vue-template-es2015-compiler": "^1.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4725,6 +4725,11 @@ source-map@0.1.x:
   dependencies:
     amdefine ">=0.0.4"
 
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 source-map@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -4736,16 +4741,6 @@ source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
-
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 spdx-correct@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Revert `source-map` to v0.6.1 as starting `0.7.0` there is no sync API.