### PR TITLE
feat: implement ::-v-deep as a shadow piercing combinator

### DIFF
--- a/lib/stylePlugins/scoped.ts
+++ b/lib/stylePlugins/scoped.ts
@@ -24,6 +24,7 @@ export default postcss.plugin('add-id', (options: any) => (root: Root) => {
       selectors.each((selector: any) => {
         let node: any = null
 
+        // find the last child node to insert attribute selector
         selector.each((n: any) => {
           // ">>>" combinator
           // and /deep/ alias for >>>, since >>> doesn't work in SASS
@@ -35,6 +36,13 @@ export default postcss.plugin('add-id', (options: any) => (root: Root) => {
             n.spaces.before = n.spaces.after = ''
             return false
           }
+
+          // in newer versions of sass, /deep/ support is also dropped, so add a ::v-deep alias
+          if (n.type === 'pseudo' && n.value === '::v-deep') {
+            n.value = n.spaces.before = n.spaces.after = ''
+            return false
+          }
+
           if (n.type !== 'pseudo' && n.type !== 'combinator') {
             node = n
           }

--- a/lib/stylePlugins/scoped.ts
+++ b/lib/stylePlugins/scoped.ts
@@ -37,8 +37,8 @@ export default postcss.plugin('add-id', (options: any) => (root: Root) => {
             return false
           }
 
-          // in newer versions of sass, /deep/ support is also dropped, so add a ::v-deep alias
-          if (n.type === 'pseudo' && n.value === '::v-deep') {
+          // in newer versions of sass, /deep/ support is also dropped, so add a ::-v-deep alias
+          if (n.type === 'pseudo' && n.value === '::-v-deep') {
             n.value = n.spaces.before = n.spaces.after = ''
             return false
           }

--- a/lib/stylePlugins/scoped.ts
+++ b/lib/stylePlugins/scoped.ts
@@ -37,8 +37,8 @@ export default postcss.plugin('add-id', (options: any) => (root: Root) => {
             return false
           }
 
-          // in newer versions of sass, /deep/ support is also dropped, so add a ::-v-deep alias
-          if (n.type === 'pseudo' && n.value === '::-v-deep') {
+          // in newer versions of sass, /deep/ support is also dropped, so add a ::v-deep alias
+          if (n.type === 'pseudo' && n.value === '::v-deep') {
             n.value = n.spaces.before = n.spaces.after = ''
             return false
           }

--- a/test/stylePluginScoped.spec.ts
+++ b/test/stylePluginScoped.spec.ts
@@ -77,7 +77,7 @@ h1 {
   color: red;
 }
 
-.foo span ::-v-deep .bar {
+.foo span ::v-deep .bar {
   color: red;
 }
 `

--- a/test/stylePluginScoped.spec.ts
+++ b/test/stylePluginScoped.spec.ts
@@ -77,7 +77,7 @@ h1 {
   color: red;
 }
 
-.foo span ::v-deep .bar {
+.foo span ::-v-deep .bar {
   color: red;
 }
 `
@@ -111,7 +111,7 @@ h1 {
   expect(style).toContain(`.foo p[v-scope-xxx] .bar {\n  color: red;\n}`)
   // /deep/ alias for >>>
   expect(style).toContain(`.foo div[v-scope-xxx] .bar {\n  color: red;\n}`)
-  // ::v-deep alias for >>>
+  // ::-v-deep alias for >>>
   expect(style).toContain(`.foo span[v-scope-xxx]  .bar {\n  color: red;\n}`)
 })
 

--- a/test/stylePluginScoped.spec.ts
+++ b/test/stylePluginScoped.spec.ts
@@ -76,6 +76,10 @@ h1 {
 .foo div /deep/ .bar {
   color: red;
 }
+
+.foo span ::v-deep .bar {
+  color: red;
+}
 `
   })
 
@@ -107,6 +111,8 @@ h1 {
   expect(style).toContain(`.foo p[v-scope-xxx] .bar {\n  color: red;\n}`)
   // /deep/ alias for >>>
   expect(style).toContain(`.foo div[v-scope-xxx] .bar {\n  color: red;\n}`)
+  // ::v-deep alias for >>>
+  expect(style).toContain(`.foo span[v-scope-xxx]  .bar {\n  color: red;\n}`)
 })
 
 test('pseudo element', () => {


### PR DESCRIPTION
- `>>>` is semantically invalid in a stylesheet
- `/deep/` was deprecated and removed from all browsers, and [dart-sass no longer supports parsing it](https://github.com/sass/dart-sass/issues/154)
- Angular implemented the `::ng-deep` alias https://github.com/angular/angular/pull/17677

In the long run we should move to shadow parts for such use cases. See [this article](https://meowni.ca/posts/part-theme-explainer/) (the syntax has slightly change since the article published but the idea remains).

A caveats of this implementation: since `::-v-deep` is parsed as a pseudo element, we can't elegantly remove the arounding spaces, so there's an extra space remained in the added test case.

Update: as @Justineo pointed out, it is a common practice for a vendor prefixed selector to start with `-`, so renamed it to `::-v-deep`.