### PR TITLE
chore: use `files` field instead of `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-test
-jest.config.js
-tsconfig.json
-*.log
-*.lock
-.circleci
-coverage

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Lower level utilities for compiling Vue single file components",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "prettier --write \"{lib,test}/**/*.ts\"",
     "test": "prettier --list-different \"{lib,test}/**/*.ts\" && jest --coverage",


### PR DESCRIPTION
Should not include `lib` directory in the published package.
Thanks @hawkeye64 for pointing out.