### PR TITLE
feat: support audio src in `transformAssetUrls` option by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ interface TemplateCompileOptions {
   // Transform asset urls found in the template into `require()` calls
   // This is off by default. If set to true, the default value is
   // {
+  //   audio: 'src',
   //   video: ['src', 'poster'],
   //   source: 'src',
   //   img: 'src',

--- a/lib/templateCompilerModules/assetUrl.ts
+++ b/lib/templateCompilerModules/assetUrl.ts
@@ -7,6 +7,7 @@ export interface AssetURLOptions {
 }
 
 const defaultOptions: AssetURLOptions = {
+  audio: 'src',
   video: ['src', 'poster'],
   source: 'src',
   img: 'src',


### PR DESCRIPTION
fix issues like
https://github.com/vuejs/vue-cli/issues/4792
and
https://github.com/nuxt/docs/pull/1256