### PR TITLE
Pass the filename option to compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.log
 dist
 coverage
+.idea

--- a/lib/compileTemplate.ts
+++ b/lib/compileTemplate.ts
@@ -119,7 +119,8 @@ function actuallyCompile(
       srcsetModule()
     ]
     finalCompilerOptions = Object.assign({}, compilerOptions, {
-      modules: [...builtInModules, ...(compilerOptions.modules || [])]
+      modules: [...builtInModules, ...(compilerOptions.modules || [])],
+      filename: options.filename
     })
   }
 


### PR DESCRIPTION
Pass the filename option to compiler, so the compiler can get and pass it down in some cases like `transformNode/preTransformNode/postTransformNode`