### PR TITLE
fix: sync template compiler options

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -89,7 +89,7 @@ function generateSourceMap(
   source: string,
   generated: string,
   sourceRoot: string,
-  pad?: 'line' | 'space'
+  pad?: true | 'line' | 'space'
 ): RawSourceMap {
   const map = new SourceMapGenerator({
     file: filename.replace(/\\/g, '/'),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,13 +32,19 @@ export interface VueTemplateCompiler {
 // part of the vue monorepo.
 export interface VueTemplateCompilerOptions {
   modules?: Object[]
-  outputSourceRange?: boolean
-  whitespace?: 'preserve' | 'condense'
   directives?: { [key: string]: Function }
+  preserveWhitespace?: boolean
+  whitespace?: 'preserve' | 'condense'
+  outputSourceRange?: boolean
+  // allows tooling authors to use a non-default template compiler, which may have different options
+  [key: string]: any
 }
 
 export interface VueTemplateCompilerParseOptions {
-  pad?: 'line' | 'space'
+  pad?: true | 'line' | 'space'
+  deindent?: boolean
+  // allows tooling authors to use a non-default template compiler, which may have different options
+  [key: string]: any
 }
 
 export interface ErrorWithRange {


### PR DESCRIPTION
`VueTemplateCompilerOptions `: https://github.com/vuejs/vue/blob/b07087deae060244fe5d9651b38dc5f1e79667a9/packages/vue-template-compiler/types/index.d.ts#L6-L12

`VueTemplateCompilerParseOptions `: https://github.com/vuejs/vue/blob/b07087deae060244fe5d9651b38dc5f1e79667a9/packages/vue-template-compiler/types/index.d.ts#L190-L193