### PR TITLE
fix: add parse options to cache key

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -52,7 +52,15 @@ export function parse(options: ParseOptions): SFCDescriptor {
     sourceRoot = '',
     needMap = true
   } = options
-  const cacheKey = hash(filename + source)
+  const cacheKey = hash(
+    filename +
+      source +
+      JSON.stringify(
+        Object.entries(compilerParseOptions).sort(([key1], [key2]) =>
+          key1.localeCompare(key2)
+        )
+      )
+  )
   let output: SFCDescriptor = cache.get(cacheKey)
   if (output) return output
   output = compiler.parseComponent(source, compilerParseOptions)


### PR DESCRIPTION
Currently, if we call `parse()` on a same file with different `compilerParseOptions`, it will return the same cached result, which is supposed to be differed:

```js
const a = parse({
  source: 'aaa',
  filename: 'bbb',
  compilerParseOptions: { pad: 'line' },
})

// `b` is unexpectly cached, which leads to a wrong result
const b = parse({
  source: 'aaa',
  filename: 'bbb',
  compilerParseOptions: { pad: 'space' },
})

```