### PR TITLE
feat: upgrade prettier

### DIFF
--- a/lib/compileStyle.ts
+++ b/lib/compileStyle.ts
@@ -5,7 +5,7 @@ import scopedPlugin from './stylePlugins/scoped'
 import {
   processors,
   StylePreprocessor,
-  StylePreprocessorResults
+  StylePreprocessorResults,
 } from './styleProcessors'
 
 export interface StyleCompileOptions {
@@ -54,7 +54,7 @@ export function doCompileStyle(
     trim = true,
     preprocessLang,
     postcssOptions,
-    postcssPlugins
+    postcssPlugins,
   } = options
   const preprocessor = preprocessLang && processors[preprocessLang]
   const preProcessedSource = preprocessor && preprocess(options, preprocessor)
@@ -72,13 +72,13 @@ export function doCompileStyle(
   const postCSSOptions: ProcessOptions = {
     ...postcssOptions,
     to: filename,
-    from: filename
+    from: filename,
   }
   if (map) {
     postCSSOptions.map = {
       inline: false,
       annotation: false,
-      prev: map
+      prev: map,
     }
   }
 
@@ -98,7 +98,7 @@ export function doCompileStyle(
             code: result.css || '',
             map: result.map && result.map.toJSON(),
             errors,
-            rawResult: result
+            rawResult: result,
           })
         )
         .catch(
@@ -106,7 +106,7 @@ export function doCompileStyle(
             code: '',
             map: undefined,
             errors: [...errors, error.message],
-            rawResult: undefined
+            rawResult: undefined,
           })
         )
     }
@@ -122,7 +122,7 @@ export function doCompileStyle(
     code: code || ``,
     map: outMap && outMap.toJSON(),
     errors,
-    rawResult: result
+    rawResult: result,
   }
 }
 
@@ -135,7 +135,7 @@ function preprocess(
     options.map,
     Object.assign(
       {
-        filename: options.filename
+        filename: options.filename,
       },
       options.preprocessOptions
     )

--- a/lib/compileTemplate.ts
+++ b/lib/compileTemplate.ts
@@ -1,11 +1,11 @@
 import {
   VueTemplateCompiler,
   VueTemplateCompilerOptions,
-  ErrorWithRange
+  ErrorWithRange,
 } from './types'
 
 import assetUrlsModule, {
-  AssetURLOptions
+  AssetURLOptions,
 } from './templateCompilerModules/assetUrl'
 import srcsetModule from './templateCompilerModules/srcset'
 
@@ -43,7 +43,7 @@ export function compileTemplate(
   if (preprocessor) {
     return actuallyCompile(
       Object.assign({}, options, {
-        source: preprocess(options, preprocessor)
+        source: preprocess(options, preprocessor),
       })
     )
   } else if (preprocessLang) {
@@ -52,11 +52,11 @@ export function compileTemplate(
       code: `var render = function () {}\n` + `var staticRenderFns = []\n`,
       source: options.source,
       tips: [
-        `Component ${options.filename} uses lang ${preprocessLang} for template. Please install the language preprocessor.`
+        `Component ${options.filename} uses lang ${preprocessLang} for template. Please install the language preprocessor.`,
       ],
       errors: [
-        `Component ${options.filename} uses lang ${preprocessLang} for template, however it is not installed.`
-      ]
+        `Component ${options.filename} uses lang ${preprocessLang} for template, however it is not installed.`,
+      ],
     }
   } else {
     return actuallyCompile(options)
@@ -71,7 +71,7 @@ function preprocess(
 
   const finalPreprocessOptions = Object.assign(
     {
-      filename
+      filename,
     },
     preprocessOptions
   )
@@ -106,7 +106,7 @@ function actuallyCompile(
     isProduction = process.env.NODE_ENV === 'production',
     isFunctional = false,
     optimizeSSR = false,
-    prettify = true
+    prettify = true,
   } = options
 
   const compile =
@@ -118,11 +118,11 @@ function actuallyCompile(
       transformAssetUrls === true
         ? assetUrlsModule()
         : assetUrlsModule(transformAssetUrls),
-      srcsetModule()
+      srcsetModule(),
     ]
     finalCompilerOptions = Object.assign({}, compilerOptions, {
       modules: [...builtInModules, ...(compilerOptions.modules || [])],
-      filename: options.filename
+      filename: options.filename,
     })
   }
 
@@ -137,13 +137,13 @@ function actuallyCompile(
       code: `var render = function () {}\n` + `var staticRenderFns = []\n`,
       source,
       tips,
-      errors
+      errors,
     }
   } else {
     const finalTranspileOptions = Object.assign({}, transpileOptions, {
       transforms: Object.assign({}, transpileOptions.transforms, {
-        stripWithFunctional: isFunctional
-      })
+        stripWithFunctional: isFunctional,
+      }),
     })
 
     const toFunction = (code: string): string => {
@@ -173,7 +173,7 @@ function actuallyCompile(
         try {
           code = require('prettier').format(code, {
             semi: false,
-            parser: 'babel'
+            parser: 'babel',
           })
         } catch (e) {
           if (e.code === 'MODULE_NOT_FOUND') {
@@ -194,7 +194,7 @@ function actuallyCompile(
       code,
       source,
       tips,
-      errors
+      errors,
     }
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,14 +3,14 @@ import { parse, SFCBlock, SFCCustomBlock, SFCDescriptor } from './parse'
 import {
   compileTemplate,
   TemplateCompileOptions,
-  TemplateCompileResult
+  TemplateCompileResult,
 } from './compileTemplate'
 
 import {
   compileStyle,
   compileStyleAsync,
   StyleCompileOptions,
-  StyleCompileResults
+  StyleCompileResults,
 } from './compileStyle'
 
 // API
@@ -24,5 +24,5 @@ export {
   TemplateCompileOptions,
   TemplateCompileResult,
   StyleCompileOptions,
-  StyleCompileResults
+  StyleCompileResults,
 }

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -2,7 +2,7 @@ import { SourceMapGenerator } from 'source-map'
 import {
   RawSourceMap,
   VueTemplateCompiler,
-  VueTemplateCompilerParseOptions
+  VueTemplateCompilerParseOptions,
 } from './types'
 
 const hash = require('hash-sum')
@@ -50,7 +50,7 @@ export function parse(options: ParseOptions): SFCDescriptor {
     compiler,
     compilerParseOptions = { pad: 'line' } as VueTemplateCompilerParseOptions,
     sourceRoot = '',
-    needMap = true
+    needMap = true,
   } = options
   const cacheKey = hash(
     filename + source + JSON.stringify(compilerParseOptions)
@@ -69,7 +69,7 @@ export function parse(options: ParseOptions): SFCDescriptor {
       )
     }
     if (output.styles) {
-      output.styles.forEach(style => {
+      output.styles.forEach((style) => {
         if (!style.src) {
           style.map = generateSourceMap(
             filename,
@@ -95,15 +95,11 @@ function generateSourceMap(
 ): RawSourceMap {
   const map = new SourceMapGenerator({
     file: filename.replace(/\\/g, '/'),
-    sourceRoot: sourceRoot.replace(/\\/g, '/')
+    sourceRoot: sourceRoot.replace(/\\/g, '/'),
   })
   let offset = 0
   if (!pad) {
-    offset =
-      source
-        .split(generated)
-        .shift()!
-        .split(splitRE).length - 1
+    offset = source.split(generated).shift()!.split(splitRE).length - 1
   }
   map.setSourceContent(filename, source)
   generated.split(splitRE).forEach((line, index) => {
@@ -112,12 +108,12 @@ function generateSourceMap(
         source: filename,
         original: {
           line: index + 1 + offset,
-          column: 0
+          column: 0,
         },
         generated: {
           line: index + 1,
-          column: 0
-        }
+          column: 0,
+        },
       })
     }
   })

--- a/lib/stylePlugins/scoped.ts
+++ b/lib/stylePlugins/scoped.ts
@@ -60,7 +60,7 @@ export default postcss.plugin('add-id', (options: any) => (root: Root) => {
         selector.insertAfter(
           node,
           selectorParser.attribute({
-            attribute: id
+            attribute: id,
           })
         )
       })
@@ -72,21 +72,21 @@ export default postcss.plugin('add-id', (options: any) => (root: Root) => {
   // Caveat: this only works for keyframes and animation rules in the same
   // <style> element.
   if (Object.keys(keyframes).length) {
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       // individual animation-name declaration
       if (/^(-\w+-)?animation-name$/.test(decl.prop)) {
         decl.value = decl.value
           .split(',')
-          .map(v => keyframes[v.trim()] || v.trim())
+          .map((v) => keyframes[v.trim()] || v.trim())
           .join(',')
       }
       // shorthand
       if (/^(-\w+-)?animation$/.test(decl.prop)) {
         decl.value = decl.value
           .split(',')
-          .map(v => {
+          .map((v) => {
             const vals = v.trim().split(/\s+/)
-            const i = vals.findIndex(val => keyframes[val])
+            const i = vals.findIndex((val) => keyframes[val])
             if (i !== -1) {
               vals.splice(i, 1, keyframes[vals[i]])
               return vals.join(' ')

--- a/lib/styleProcessors/index.ts
+++ b/lib/styleProcessors/index.ts
@@ -26,7 +26,7 @@ const scss: StylePreprocessor = {
       data: source,
       file: options.filename,
       outFile: options.filename,
-      sourceMap: !!map
+      sourceMap: !!map,
     })
 
     try {
@@ -36,7 +36,7 @@ const scss: StylePreprocessor = {
         return {
           code: result.css.toString(),
           map: merge(map, JSON.parse(result.map.toString())),
-          errors: []
+          errors: [],
         }
       }
 
@@ -44,7 +44,7 @@ const scss: StylePreprocessor = {
     } catch (e) {
       return { code: '', errors: [e] }
     }
-  }
+  },
 }
 
 const sass = {
@@ -58,7 +58,7 @@ const sass = {
       map,
       Object.assign({}, options, { indentedSyntax: true })
     )
-  }
+  },
 }
 
 // .less
@@ -87,12 +87,12 @@ const less = {
       return {
         code: result.css.toString(),
         map: merge(map, result.map),
-        errors: []
+        errors: [],
       }
     }
 
     return { code: result.css.toString(), errors: [] }
-  }
+  },
 }
 
 // .styl
@@ -105,7 +105,7 @@ const styl = {
     const nodeStylus = require('stylus')
     try {
       const ref = nodeStylus(source)
-      Object.keys(options).forEach(key => ref.set(key, options[key]))
+      Object.keys(options).forEach((key) => ref.set(key, options[key]))
       if (map) ref.set('sourcemap', { inline: false, comment: false })
 
       const result = ref.render()
@@ -113,7 +113,7 @@ const styl = {
         return {
           code: result,
           map: merge(map, ref.sourcemap),
-          errors: []
+          errors: [],
         }
       }
 
@@ -121,7 +121,7 @@ const styl = {
     } catch (e) {
       return { code: '', errors: [e] }
     }
-  }
+  },
 }
 
 export const processors: { [key: string]: StylePreprocessor } = {
@@ -129,5 +129,5 @@ export const processors: { [key: string]: StylePreprocessor } = {
   sass,
   scss,
   styl,
-  stylus: styl
+  stylus: styl,
 }

--- a/lib/templateCompilerModules/assetUrl.ts
+++ b/lib/templateCompilerModules/assetUrl.ts
@@ -12,7 +12,7 @@ const defaultOptions: AssetURLOptions = {
   source: 'src',
   img: 'src',
   image: ['xlink:href', 'href'],
-  use: ['xlink:href', 'href']
+  use: ['xlink:href', 'href'],
 }
 
 export default (userOptions?: AssetURLOptions) => {
@@ -23,7 +23,7 @@ export default (userOptions?: AssetURLOptions) => {
   return {
     postTransformNode: (node: ASTNode) => {
       transform(node, options)
-    }
+    },
   }
 }
 
@@ -32,9 +32,11 @@ function transform(node: ASTNode, options: AssetURLOptions) {
     if ((tag === '*' || node.tag === tag) && node.attrs) {
       const attributes = options[tag]
       if (typeof attributes === 'string') {
-        node.attrs.some(attr => rewrite(attr, attributes))
+        node.attrs.some((attr) => rewrite(attr, attributes))
       } else if (Array.isArray(attributes)) {
-        attributes.forEach(item => node.attrs.some(attr => rewrite(attr, item)))
+        attributes.forEach((item) =>
+          node.attrs.some((attr) => rewrite(attr, item))
+        )
       }
     }
   }

--- a/lib/templateCompilerModules/srcset.ts
+++ b/lib/templateCompilerModules/srcset.ts
@@ -10,7 +10,7 @@ interface ImageCandidate {
 export default () => ({
   postTransformNode: (node: ASTNode) => {
     transform(node)
-  }
+  },
 })
 
 // http://w3c.github.io/html/semantics-embedded-content.html#ref-for-image-candidate-string-5
@@ -20,7 +20,7 @@ function transform(node: ASTNode) {
   const tags = ['img', 'source']
 
   if (tags.indexOf(node.tag) !== -1 && node.attrs) {
-    node.attrs.forEach(attr => {
+    node.attrs.forEach((attr) => {
       if (attr.name === 'srcset') {
         // same logic as in transform-require.js
         const value = attr.value
@@ -33,7 +33,7 @@ function transform(node: ASTNode) {
         const imageCandidates: ImageCandidate[] = value
           .substr(1, value.length - 2)
           .split(',')
-          .map(s => {
+          .map((s) => {
             // The attribute value arrives here with all whitespace, except
             // normal spaces, represented by escape sequences
             const [url, descriptor] = s

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "vue-template-es2015-compiler": "^1.9.0"
   },
   "optionalDependencies": {
-    "prettier": "^1.18.2"
+    "prettier": "^2.0.5"
   }
 }

--- a/test/compileStyle.spec.ts
+++ b/test/compileStyle.spec.ts
@@ -12,7 +12,7 @@ test('preprocess less', () => {
       '</style>\n',
     compiler: compiler as VueTemplateCompiler,
     filename: 'example.vue',
-    needMap: true
+    needMap: true,
   }).styles[0]
   const result = compileStyle({
     id: 'v-scope-xxx',
@@ -20,7 +20,7 @@ test('preprocess less', () => {
     source: style.content,
     map: style.map,
     scoped: false,
-    preprocessLang: style.lang
+    preprocessLang: style.lang,
   })
 
   expect(result.errors.length).toBe(0)
@@ -37,7 +37,7 @@ test('preprocess scss', () => {
       '</style>\n',
     compiler: compiler as VueTemplateCompiler,
     filename: 'example.vue',
-    needMap: true
+    needMap: true,
   }).styles[0]
   const result = compileStyle({
     id: 'v-scope-xxx',
@@ -45,7 +45,7 @@ test('preprocess scss', () => {
     source: style.content,
     map: style.map,
     scoped: false,
-    preprocessLang: style.lang
+    preprocessLang: style.lang,
   })
 
   expect(result.errors.length).toBe(0)
@@ -63,7 +63,7 @@ test('preprocess sass', () => {
       '</style>\n',
     compiler: compiler as VueTemplateCompiler,
     filename: 'example.vue',
-    needMap: true
+    needMap: true,
   }).styles[0]
   const result = compileStyle({
     id: 'v-scope-xxx',
@@ -71,7 +71,7 @@ test('preprocess sass', () => {
     source: style.content,
     map: style.map,
     scoped: false,
-    preprocessLang: style.lang
+    preprocessLang: style.lang,
   })
 
   expect(result.errors.length).toBe(0)
@@ -89,7 +89,7 @@ test('preprocess stylus', () => {
       '</style>\n',
     compiler: compiler as VueTemplateCompiler,
     filename: 'example.vue',
-    needMap: true
+    needMap: true,
   }).styles[0]
   const result = compileStyle({
     id: 'v-scope-xxx',
@@ -97,7 +97,7 @@ test('preprocess stylus', () => {
     source: style.content,
     map: style.map,
     scoped: false,
-    preprocessLang: style.lang
+    preprocessLang: style.lang,
   })
 
   expect(result.errors.length).toBe(0)
@@ -113,7 +113,7 @@ test('custom postcss plugin', () => {
     filename: 'example.vue',
     source: '.foo { color: red }',
     scoped: false,
-    postcssPlugins: [require('postcss').plugin('test-plugin', () => spy)()]
+    postcssPlugins: [require('postcss').plugin('test-plugin', () => spy)()],
   })
 
   expect(spy).toHaveBeenCalled()
@@ -125,7 +125,7 @@ test('custom postcss options', () => {
     filename: 'example.vue',
     source: '.foo { color: red }',
     scoped: false,
-    postcssOptions: { random: 'foo' }
+    postcssOptions: { random: 'foo' },
   })
 
   expect((result.rawResult as any).opts.random).toBe('foo')
@@ -140,8 +140,8 @@ test('async postcss plugin in sync mode', () => {
     postcssPlugins: [
       require('postcss').plugin('test-plugin', () => async (result: any) =>
         result
-      )
-    ]
+      ),
+    ],
   })
 
   expect(result.errors).toHaveLength(1)
@@ -156,8 +156,8 @@ test('async postcss plugin', async () => {
     postcssPlugins: [
       require('postcss').plugin('test-plugin', () => async (result: any) =>
         result
-      )
-    ]
+      ),
+    ],
   })
 
   expect(promise instanceof Promise).toBe(true)
@@ -177,7 +177,7 @@ test('media query', () => {
   .foo {
     color: #000;
   }
-}`
+}`,
   })
 
   expect(result.errors).toHaveLength(0)
@@ -196,7 +196,7 @@ test('supports query', () => {
   .foo {
     color: #000;
   }
-}`
+}`,
   })
 
   expect(result.errors).toHaveLength(0)

--- a/test/compileTemplate.spec.ts
+++ b/test/compileTemplate.spec.ts
@@ -22,7 +22,7 @@ test('should work', () => {
   const result = compileTemplate({
     filename: 'example.vue',
     source,
-    compiler: compiler as VueTemplateCompiler
+    compiler: compiler as VueTemplateCompiler,
   })
 
   expect(result.errors.length).toBe(0)
@@ -48,14 +48,14 @@ test('preprocess pug', () => {
       '</template>\n',
     compiler: compiler as VueTemplateCompiler,
     filename: 'example.vue',
-    needMap: true
+    needMap: true,
   }).template as compiler.SFCBlock
 
   const result = compileTemplate({
     filename: 'example.vue',
     source: template.content,
     preprocessLang: template.lang,
-    compiler: compiler as VueTemplateCompiler
+    compiler: compiler as VueTemplateCompiler,
   })
 
   expect(result.errors.length).toBe(0)
@@ -72,9 +72,9 @@ test('supports uri fragment in transformed require', () => {
     filename: 'svgparticle.html',
     source: source,
     transformAssetUrls: {
-      use: 'href'
+      use: 'href',
     },
-    compiler: compiler as VueTemplateCompiler
+    compiler: compiler as VueTemplateCompiler,
   })
   expect(result.errors.length).toBe(0)
   expect(result.code).toMatch(
@@ -93,9 +93,9 @@ test('when too short uri then empty require', () => {
     filename: 'svgparticle.html',
     source: source,
     transformAssetUrls: {
-      use: 'href'
+      use: 'href',
     },
-    compiler: compiler as VueTemplateCompiler
+    compiler: compiler as VueTemplateCompiler,
   })
   expect(result.errors.length).toBe(0)
   expect(result.code).toMatch(/href: require\(""\)/)
@@ -106,14 +106,14 @@ test('warn missing preprocessor', () => {
     source: '<template lang="unknownLang">\n' + '</template>\n',
     compiler: compiler as VueTemplateCompiler,
     filename: 'example.vue',
-    needMap: true
+    needMap: true,
   }).template as compiler.SFCBlock
 
   const result = compileTemplate({
     filename: 'example.vue',
     source: template.content,
     preprocessLang: template.lang,
-    compiler: compiler as VueTemplateCompiler
+    compiler: compiler as VueTemplateCompiler,
   })
 
   expect(result.errors.length).toBe(1)
@@ -131,7 +131,7 @@ test('transform assetUrls', () => {
     compiler: compiler as VueTemplateCompiler,
     filename: 'example.vue',
     source,
-    transformAssetUrls: true
+    transformAssetUrls: true,
   })
   expect(result.errors.length).toBe(0)
 
@@ -174,7 +174,7 @@ test('transform srcset', () => {
     compiler: compiler as VueTemplateCompiler,
     filename: 'example.vue',
     source,
-    transformAssetUrls: true
+    transformAssetUrls: true,
   })
   expect(result.errors.length).toBe(0)
 

--- a/test/stylePluginScoped.spec.ts
+++ b/test/stylePluginScoped.spec.ts
@@ -5,7 +5,7 @@ test('spaces after selector', () => {
   const { code } = compileStyle({
     source: `.foo , .bar { color: red; }`,
     filename: 'test.css',
-    id: 'test'
+    id: 'test',
   })
 
   expect(code).toMatch(`.foo[test], .bar[test] { color: red;`)
@@ -15,7 +15,7 @@ test('leading deep selector', () => {
   const { code } = compileStyle({
     source: `>>> .foo { color: red; }`,
     filename: 'test.css',
-    id: 'test'
+    id: 'test',
   })
 
   expect(code).toMatch(`[test] .foo { color: red;`)
@@ -80,7 +80,7 @@ h1 {
 .foo span ::v-deep .bar {
   color: red;
 }
-`
+`,
   })
 
   expect(style).toContain(`.test[v-scope-xxx] {\n  color: yellow;\n}`)
@@ -119,7 +119,7 @@ test('pseudo element', () => {
   const { code } = compileStyle({
     source: '::selection { display: none; }',
     filename: 'test.css',
-    id: 'test'
+    id: 'test',
   })
 
   expect(code).toContain('[test]::selection {')
@@ -129,7 +129,7 @@ test('spaces before pseudo element', () => {
   const { code } = compileStyle({
     source: '.abc, ::selection { color: red; }',
     filename: 'test.css',
-    id: 'test'
+    id: 'test',
   })
 
   expect(code).toContain('.abc[test],')

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,11 +464,6 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
 acorn-globals@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
@@ -585,19 +580,6 @@ anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
-
-aproba@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
-  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1013,11 +995,6 @@ character-parser@^2.1.1:
   optionalDependencies:
     fsevents "~2.1.2"
 
-chownr@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
-  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
-
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
@@ -1142,11 +1119,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
-
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 consolidate@^0.15.1:
   version "0.15.1"
@@ -1460,7 +1432,7 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1503,11 +1475,6 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -1559,16 +1526,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -1913,13 +1870,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1951,20 +1901,6 @@ g-status@^2.0.2:
     arrify "^1.0.1"
     matcher "^1.0.0"
     simple-git "^1.85.0"
-
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
 
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
@@ -2142,11 +2078,6 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
-
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
@@ -2221,19 +2152,12 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 image-size@~0.5.0:
   version "0.5.5"
@@ -2291,7 +2215,7 @@ inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.2, ini@~1.3.0:
+ini@^1.3.2:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -3535,21 +3459,6 @@ minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -3607,15 +3516,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.1.tgz#14af48732463d7475696f937626b1b993247a56a"
-  integrity sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
@@ -3647,30 +3547,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
-
 normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -3698,27 +3574,6 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-path@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
@@ -3741,16 +3596,6 @@ npm-which@^3.0.1:
     commander "^2.9.0"
     npm-path "^2.0.2"
     which "^1.2.10"
-
-npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -3848,24 +3693,6 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
-
-os-homedir@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
-
-os-tmpdir@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
-
-osenv@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
-  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.0"
 
 p-each-series@^1.0.0:
   version "1.0.0"
@@ -4101,10 +3928,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.18.2:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-format@^24.9.0:
   version "24.9.0"
@@ -4289,16 +4116,6 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -4355,7 +4172,7 @@ read-pkg@^3.0.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^2.0.6, readable-stream@~2.3.6:
+readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -4539,7 +4356,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
+rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -4612,7 +4429,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -4622,7 +4439,7 @@ semver@^6.0.0, semver@^6.2.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -4862,7 +4679,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.1.1:
+string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -4986,11 +4803,6 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 stylus@^0.54.5:
   version "0.54.7"
   resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.54.7.tgz#c6ce4793965ee538bcebe50f31537bfc04d88cd2"
@@ -5038,19 +4850,6 @@ synchronous-promise@^2.0.6:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.10.tgz#e64c6fd3afd25f423963353043f4a68ebd397fd8"
   integrity sha512-6PC+JRGmNjiG3kJ56ZMNWDPL8hjyghF5cMXIFOKg+NiwwEZZIvxTWd0pinWKyD227odg9ygF8xVhhz7gb8Uq7A==
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 temp-dir@^2.0.0:
   version "2.0.0"
@@ -5421,13 +5220,6 @@ which@^1.2.10, which@^1.2.9, which@^1.3.0:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
-
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -5513,11 +5305,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-
-yallist@^3.0.0, yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@10.x, yargs-parser@^10.0.0:
   version "10.1.0"


### PR DESCRIPTION
Literally just bump `prettier`.

Unfortunately, this brings with it some new defaults, and a load of irrelevant changes. If you want, you can disable `trailingComma` in `.prettierrc`, instead?

This is useful to me because it reduces the number of copies of `prettier` I have to install, as `optional` in `npm` doesn't actually mean `optional`.