### PR TITLE
feat: add `forceRequire` for asset

### DIFF
--- a/lib/templateCompilerModules/assetUrl.ts
+++ b/lib/templateCompilerModules/assetUrl.ts
@@ -7,11 +7,7 @@ export interface AssetURLOptions {
 }
 
 export interface TransformAssetUrlsOptions {
-  /**
-   * If base is provided, instead of transforming relative asset urls into
-   * imports, they will be directly rewritten to absolute urls.
-   */
-  base?: string
+  forceRequire?: boolean
 }
 
 const defaultOptions: AssetURLOptions = {

--- a/lib/templateCompilerModules/assetUrl.ts
+++ b/lib/templateCompilerModules/assetUrl.ts
@@ -7,6 +7,12 @@ export interface AssetURLOptions {
 }
 
 export interface TransformAssetUrlsOptions {
+  /**
+   * @deprecated
+   * If base is provided, instead of transforming relative asset urls into
+   * imports, they will be directly rewritten to absolute urls.
+   */
+  base?: string
   forceRequire?: boolean
 }
 

--- a/lib/templateCompilerModules/utils.ts
+++ b/lib/templateCompilerModules/utils.ts
@@ -1,5 +1,6 @@
 import { TransformAssetUrlsOptions } from './assetUrl'
 import { UrlWithStringQuery, parse as uriParse } from 'url'
+import path from 'path'
 
 export interface Attr {
   name: string
@@ -27,6 +28,21 @@ export function urlToRequire(
   }
 
   const uriParts = parseUriParts(url)
+
+  if (transformAssetUrlsOption.base) {
+    // explicit base - directly rewrite the url into absolute url
+    // does not apply to absolute urls or urls that start with `@`
+    // since they are aliases
+    if (firstChar === '.' || firstChar === '~') {
+      // when packaged in the browser, path will be using the posix-
+      // only version provided by rollup-plugin-node-builtins.
+      return `"${(path.posix || path).join(
+        transformAssetUrlsOption.base,
+        uriParts.path + (uriParts.hash || '')
+      )}"`
+    }
+    return returnValue
+  }
 
   if (
     firstChar === '.' ||

--- a/test/compileTemplate.spec.ts
+++ b/test/compileTemplate.spec.ts
@@ -205,12 +205,40 @@ test('transform srcset', () => {
   expect(vnode.children[18].data.attrs.srcset).toBe('test-url 2x, test-url 3x')
 })
 
+test('transform assetUrls and srcset with base option', () => {
+  const source = `
+  <div>
+    <img src="./logo.png">
+    <img src="~fixtures/logo.png">
+    <img src="~/fixtures/logo.png">
+    <img src="./logo.png" srcset="./logo.png 2x, ./logo.png 3x">
+  </div>
+  `
+  const result = compileTemplate({
+    compiler: compiler as VueTemplateCompiler,
+    filename: 'example.vue',
+    source,
+    transformAssetUrls: true,
+    transformAssetUrlsOptions: { base: '/base/' }
+  })
+
+  expect(result.errors.length).toBe(0)
+
+  const vnode = mockRender(result.code)
+  expect(vnode.children[0].data.attrs.src).toBe('/base/logo.png')
+  expect(vnode.children[2].data.attrs.src).toBe('/base/fixtures/logo.png')
+  expect(vnode.children[4].data.attrs.src).toBe('/base/fixtures/logo.png')
+  expect(vnode.children[6].data.attrs.srcset).toBe(
+    '/base/logo.png 2x, /base/logo.png 3x'
+  )
+})
+
 test('transform assetUrls and srcset with forceRequire option', () => {
   const source = `
-<div>
-  <img src="/@/logo.png">
-</div>
-`
+  <div>
+    <img src="/@/logo.png">
+  </div>
+  `
   const result = compileTemplate({
     compiler: compiler as VueTemplateCompiler,
     filename: 'example.vue',

--- a/test/compileTemplate.spec.ts
+++ b/test/compileTemplate.spec.ts
@@ -205,13 +205,10 @@ test('transform srcset', () => {
   expect(vnode.children[18].data.attrs.srcset).toBe('test-url 2x, test-url 3x')
 })
 
-test('transform assetUrls and srcset with base option', () => {
+test('transform assetUrls and srcset with forceRequire option', () => {
   const source = `
 <div>
-  <img src="./logo.png">
-  <img src="~fixtures/logo.png">
-  <img src="~/fixtures/logo.png">
-  <img src="./logo.png" srcset="./logo.png 2x, ./logo.png 3x">
+  <img src="/@/logo.png">
 </div>
 `
   const result = compileTemplate({
@@ -219,16 +216,13 @@ test('transform assetUrls and srcset with base option', () => {
     filename: 'example.vue',
     source,
     transformAssetUrls: true,
-    transformAssetUrlsOptions: { base: '/base/' }
+    transformAssetUrlsOptions: { forceRequire: true }
   })
+
+  jest.mock('/@/logo.png', () => 'test-url', { virtual: true })
 
   expect(result.errors.length).toBe(0)
 
   const vnode = mockRender(result.code)
-  expect(vnode.children[0].data.attrs.src).toBe('/base/logo.png')
-  expect(vnode.children[2].data.attrs.src).toBe('/base/fixtures/logo.png')
-  expect(vnode.children[4].data.attrs.src).toBe('/base/fixtures/logo.png')
-  expect(vnode.children[6].data.attrs.srcset).toBe(
-    '/base/logo.png 2x, /base/logo.png 3x'
-  )
+  expect(vnode.children[0].data.attrs.src).toBe('test-url')
 })


### PR DESCRIPTION
I am working for fix alias asset resolver at vite2,  i scan `require` call to rewrite it to es module synax, but i find the alias asset isn't resolve by transformed to `require('xxx')`,.So i add this option to force transform to `require` call.

The `base` option will be not used, so i remove it.