### PR TITLE
fix: add undeclared dependencies `chalk` and `supports-color`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,12 +65,14 @@
     "yorkie": "^2.0.0"
   },
   "dependencies": {
+    "chalk": "^2.4.2",
     "consolidate": "^0.15.1",
     "hash-sum": "^1.0.2",
     "lru-cache": "^4.1.2",
     "merge-source-map": "^1.1.0",
     "postcss-selector-parser": "^6.0.2",
     "source-map": "~0.6.1",
+    "supports-color": "^6.1.0",
     "vue-template-es2015-compiler": "^1.9.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/vuejs/component-compiler-utils/pull/111 started bundling postcss but didn't declare the dependencies it needs

Fixes https://github.com/yarnpkg/berry/runs/2780231720?check_suite_focus=true#step:5:114

**How did you fix it?**

Added undeclared dependencies `chalk` and `supports-color`