### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/templateCompilerModules/srcset.ts
+++ b/lib/templateCompilerModules/srcset.ts
@@ -35,7 +35,7 @@ function transform(
         }
 
         const imageCandidates: ImageCandidate[] = value
-          .substr(1, value.length - 2)
+          .slice(1, -1)
           .split(',')
           .map(s => {
             // The attribute value arrives here with all whitespace, except


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.